### PR TITLE
Fix breakage from removal of Arduino_TensorFlowLite dependency from Library Manager

### DIFF
--- a/.github/workflows/arduino.yml
+++ b/.github/workflows/arduino.yml
@@ -44,6 +44,7 @@ jobs:
           - name: Arduino_LSM9DS1
           - name: Servo
           - name: Adafruit Thermal Printer Library
-          - name: Arduino_TensorFlowLite
+          - source-url: https://github.com/tensorflow/tflite-micro-arduino-examples.git
+            destination-name: Arduino_TensorFlowLite
           - name: Adafruit SSD1306
           - name: Adafruit GFX Library

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ The dependencies of this library are specified on the [library.properties](libra
 * [Arduino_APDS9960](https://github.com/arduino-libraries/Arduino_APDS9960): APDS9960 sensor, to read gestures, color, proximity.
 * [Arduino_KNN](https://github.com/arduino-libraries/Arduino_KNN): for machine learning with K-Nearest Neighbors algorithm.
 * [Arduino_LSM9DS1](https://github.com/arduino-libraries/Arduino_LSM9DS1): LSM9DS1 IMU sensor, to read accelerometer, magnetometer, gyroscope.
-* [Arduino_TensorFlowLite](https://www.arduino.cc/reference/en/libraries/arduino_tensorflowlite/): for machine learning with TensorFlow.
 * [Servo](https://github.com/arduino-libraries/Servo): output with servo motors.
+
+There is an additional dependency that must be installed manually:
+
+* [Arduino_TensorFlowLite](https://github.com/tensorflow/tflite-micro-arduino-examples): for machine learning with TensorFlow.
 
 ## Contents
 

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Other
 url=https://github.com/montoyamoraga/TinyTrainable
 architectures=mbed_nano
 includes=TinyTrainable.h
-depends= Adafruit GFX Library, Adafruit SSD1306, Adafruit Thermal Printer Library, Arduino_APDS9960, Arduino_KNN, Arduino_LSM9DS1, Arduino_TensorFlowLite, Servo
+depends= Adafruit GFX Library, Adafruit SSD1306, Adafruit Thermal Printer Library, Arduino_APDS9960, Arduino_KNN, Arduino_LSM9DS1, Servo


### PR DESCRIPTION
The "**Arduino_TensorFlowLite**" library is a dependency of this project.

This dependency was previously included in the Arduino Library Manager index, which was used by the project in the following ways:

- Specified as dependency in metadata to provide automated installation along with **TinyTrainable**
- Referenced by name alone in the library dependencies configuration of the "**Arduino Compile**" GitHub Actions workflow
- Link to the generated library reference on arduino.cc

The library was removed from the Arduino Library Manager index at the request of the TensorFlow Lite Micro maintainers (https://github.com/arduino/library-registry/pull/1748), which broke all three of the usages listed above.

That breakage is hereby repaired:

### Library metadata

All libraries listed in the `depends` field of the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#library-metadata) must be available for installation from Library Manager. The presence of `Arduino_TensorFlowLite` on that list causes the library installation to ['fail with Arduino IDE 2.x](https://github.com/arduino/arduino-ide/issues/621), or [`arduino-cli lib install TinyTrainable`](https://arduino.github.io/arduino-cli/latest/commands/arduino-cli_lib_install/). The library is removed from the list.

### GitHub Actions workflow

The previous configuration of the "Arduino Compile" GitHub Actions workflow caused it to install the dependency from Library Manager, which will now result in a failure:

```text
Running command: /home/runner/bin/arduino-cli lib install Arduino_TensorFlowLite 
   Error installing Arduino_TensorFlowLite: Library 'Arduino_TensorFlowLite' not found
```

The workflow is here adjusted to install the library by cloning [the official `tensorflow/tflite-micro-arduino-examples` repository](https://github.com/tensorflow/tflite-micro-arduino-examples). Since that repository does not currently provide any [tags](https://github.com/tensorflow/tflite-micro-arduino-examples/tags), the workflow is [configured](https://github.com/arduino/compile-sketches#libraries) to use the version of the library from the tip of the main branch.

Note that the library does not compile with the version of the library from the tip of the main branch of the `tensorflow/tflite-micro-arduino-examples` repository:

```text
Compiling sketch: examples/check/check_buzzer
  In file included from /home/runner/Arduino/libraries/TinyTrainable/src/TinyTrainable.cpp:11:0:
  /home/runner/Arduino/libraries/TinyTrainable/src/inputs/InputGesture.h:26:10: fatal error: tensorflow/lite/version.h: No such file or directory
   #include <tensorflow/lite/version.h>
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~
  compilation terminated.
```

The header file does not (and never did) exist in the version of the library from the `tensorflow/tflite-micro-arduino-examples` repository:

https://github.com/tensorflow/tflite-micro-arduino-examples/tree/main/src/tensorflow/lite

So this will need to be resolved by adjusting the **TinyTrainable** code, which is out of scope for this PR.

### Documentation

The readme is updated to specify that the "**Arduino_TensorFlowLite**" library must be installed manually, and the link updated from the obsolete generated reference page to the official repository for the library, which [contains manual installation instructions](https://github.com/tensorflow/tflite-micro-arduino-examples#how-to-install).